### PR TITLE
Add optional support for the ODROID-C4

### DIFF
--- a/libclock/include/clock/device.h
+++ b/libclock/include/clock/device.h
@@ -11,10 +11,21 @@
  */
 #pragma once
 
+#include <sel4/types.h>
+
+#if defined(CONFIG_PLAT_ODROIDC2)
 #define TIMER_BASE      0xc1100000
 #define TIMER_MAP_BASE  0xc1109000
 
 #define TIMER_REG_START   0x940    // TIMER_MUX
+#elif defined(CONFIG_PLAT_ODROIDC4)
+#define TIMER_BASE      0xffd00000
+#define TIMER_MAP_BASE  0xffd0f000
+
+#define TIMER_REG_START   0x3c50    // TIMER_MUX
+#else
+#error "only odroid-c2 and odroid-c4 supported currently."
+#endif
 
 /**
  * Identifiers for each of the timeout timers.

--- a/libethernet/include/ethernet/ethernet.h
+++ b/libethernet/include/ethernet/ethernet.h
@@ -11,6 +11,8 @@
  */
 #pragma once
 
+#include <autoconf.h>
+
 #include <stdint.h>
 
 /**
@@ -23,8 +25,15 @@
  * MMIO address of the ethernet MAC, for use by sos_map_device. The virtual address
  * that the device is mapped at should then be passed to ethif_init as the base address.
  */
-#define ODROIDC2_ETH_PHYS_ADDR      0xc9410000
-#define ODROIDC2_ETH_PHYS_SIZE         0x10000
+#if defined(CONFIG_PLAT_ODROIDC2)
+#define ETH_PHYS_ADDR      0xc9410000
+#define ETH_PHYS_SIZE         0x10000
+#elif defined(CONFIG_PLAT_ODROIDC4)
+#define ETH_PHYS_ADDR      0xFF3F0000
+#define ETH_PHYS_SIZE         0x10000
+#else
+#error "only odroid-c2 and odroid-c4 supported currently."
+#endif
 
 #define MAXIMUM_TRANSFER_UNIT             1500
 

--- a/sos/src/drivers/uart.c
+++ b/sos/src/drivers/uart.c
@@ -14,7 +14,13 @@
 #include "../mapping.h"
 #include "uart.h"
 
+#if defined(CONFIG_PLAT_ODROIDC2)
 #define UART_PADDR 0xc81004c0
+#elif defined(CONFIG_PLAT_ODROIDC4)
+#define UART_PADDR 0xFF803000
+#else
+#error "only odroid-c2 and odroid-c4 supported currently."
+#endif
 
 static volatile struct {
     uint32_t wfifo;

--- a/sos/src/network.c
+++ b/sos/src/network.c
@@ -228,7 +228,7 @@ void network_init(cspace_t *cspace, void *timer_vaddr, seL4_CPtr irq_ntfn)
 
     /* Map the ethernet MAC MMIO registers into our address space */
     uint64_t eth_base_vaddr =
-        (uint64_t)sos_map_device(cspace, ODROIDC2_ETH_PHYS_ADDR, ODROIDC2_ETH_PHYS_SIZE);
+        (uint64_t)sos_map_device(cspace, ETH_PHYS_ADDR, ETH_PHYS_SIZE);
 
     /* Populate DMA operations required by the ethernet driver */
     ethif_dma_ops_t ethif_dma_ops;


### PR DESCRIPTION
To use, change:

set(PLATFORM odroidc2 CACHE STRING "" FORCE)

to:

set(PLATFORM odroidc4 CACHE STRING "" FORCE)

in settings.cmake.

Signed-off-by: Ahmed Charles <acharles@outlook.com>