### PR TITLE
Remove unnecessary and misleading cache ops

### DIFF
--- a/sos/src/elf.c
+++ b/sos/src/elf.c
@@ -147,16 +147,6 @@ static int load_segment_into_vspace(cspace_t *cspace, seL4_CPtr loadee, const ch
             memset(loader_data, 0, segment_bytes);
         }
 
-        /* Flush the frame contents from loader caches out to memory. */
-        flush_frame(frame);
-
-        /* Invalidate the caches in the loadee forcing data to be loaded
-         * from memory. */
-        if (seL4_CapRights_get_capAllowWrite(permissions)) {
-            seL4_ARM_Page_Invalidate_Data(loadee_frame, 0, PAGE_SIZE_4K);
-        }
-        seL4_ARM_Page_Unify_Instruction(loadee_frame, 0, PAGE_SIZE_4K);
-
         pos += segment_bytes;
         dst += segment_bytes;
         src += segment_bytes;

--- a/sos/src/frame_table.c
+++ b/sos/src/frame_table.c
@@ -152,19 +152,6 @@ unsigned char *frame_data(frame_ref_t frame_ref)
     return frame_table.frame_data[frame_ref];
 }
 
-void flush_frame(frame_ref_t frame_ref)
-{
-    frame_t *frame = frame_from_ref(frame_ref);
-    seL4_ARM_Page_Clean_Data(frame->sos_page, 0, BIT(seL4_PageBits));
-    seL4_ARM_Page_Unify_Instruction(frame->sos_page, 0, BIT(seL4_PageBits));
-}
-
-void invalidate_frame(frame_ref_t frame_ref)
-{
-    frame_t *frame = frame_from_ref(frame_ref);
-    seL4_ARM_Page_Invalidate_Data(frame->sos_page, 0, BIT(seL4_PageBits));
-}
-
 frame_t *frame_from_ref(frame_ref_t frame_ref)
 {
     assert(frame_ref != NULL_FRAME);

--- a/sos/src/frame_table.h
+++ b/sos/src/frame_table.h
@@ -122,24 +122,6 @@ void free_frame(frame_ref_t frame_ref);
 unsigned char *frame_data(frame_ref_t frame_ref);
 
 /*
- * Flush any cached values for a frame out to physical memory.
- *
- * Before allowing data to be accessed in another virtual address space
- * the cache should be flushed to ensure that the correct data is
- * observed in that address space.
- */
-void flush_frame(frame_ref_t frame_ref);
-
-/*
- * Invalidate any cached memory of a frame requiring data to be fetched
- * from physical memory.
- *
- * If the frame is likely to have been changed in another virtual
- * address space it should be invalidated before being read.
- */
-void invalidate_frame(frame_ref_t frame_ref);
-
-/*
  * Get the capability to the page used to map the frame into SOS.
  *
  * This can be copied to create mappings into additional virtual address

--- a/sos/src/tests.c
+++ b/sos/src/tests.c
@@ -127,7 +127,6 @@ static void test_frame_table(void)
         unsigned char *vaddr = frame_data(frames[f]);
         vaddr[0] = f;
         vaddr[BIT(seL4_PageBits) - 1] = f;
-        flush_frame(frames[f]);
     }
 
     /* Check the writes happened */


### PR DESCRIPTION
The odroid has a PIPT cache and does not need to enforce cache coherency across virtual address spaces. However, the elf loading code and provided frame functions insinuated that cache maintenance was required. This leads to a poor understanding of cache management for students.