### PR TITLE
Remove CTIME from ps command

### DIFF
--- a/apps/sosh/src/sosh.c
+++ b/apps/sosh/src/sosh.c
@@ -153,11 +153,11 @@ static int ps(int argc, char **argv)
     }
 
     processes = sos_process_status(process, MAX_PROCESSES);
-
-    printf("TID SIZE   STIME   CTIME COMMAND\n");
+    
+    printf("TID SIZE   STIME   COMMAND\n");
 
     for (i = 0; i < processes; i++) {
-        printf("%3d %4d %7d %s\n", process[i].pid, process[i].size,
+        printf("%3d %4d %7d %9s\n", process[i].pid, process[i].size,
                process[i].stime, process[i].command);
     }
 


### PR DESCRIPTION
sosh PS command headers includes both CTIME and STIME (see JIRA issue: https://jira.unsw.edu.au/browse/CSEOS-189). While CTIME is usually returned on unix systems, IMO this isn't straightforward data for students to collect in the given timeframe, and as the command currently only prints STIME, I have simply removed the CTIME header. 
If merged, I will add clarification on this to the project spec to avoid future confusion.
If the preference is instead to print CTIME, I can update this request and add documentation to the spec to assist students in obtaining this information. 