### PR TITLE
Cspace fixes

### DIFF
--- a/libsel4cspace/include/cspace/cspace.h
+++ b/libsel4cspace/include/cspace/cspace.h
@@ -220,6 +220,14 @@ seL4_CPtr cspace_alloc_slot(cspace_t *c);
  */
 void cspace_free_slot(cspace_t *c, seL4_CPtr slot);
 
+/**
+ * Return the current size of the cspace in filled slots.
+ *
+ * @param c    The cspace
+ * @return The number of capabilities currently stored in the cspace.
+ */
+seL4_Word cspace_size(cspace_t *c);
+
 /* helper functions for cspace operations */
 
 /**

--- a/libsel4cspace/src/cspace.c
+++ b/libsel4cspace/src/cspace.c
@@ -75,7 +75,6 @@ static void refill_watermark(cspace_t *cspace, seL4_Word *used)
         if (*used & BIT(i)) {
             cspace->watermark[i] = cspace_alloc_slot(cspace);
             ZF_LOGW_IF(cspace->watermark[i] == seL4_CapNull, "Cspace full in watermark function");
-            break;
         }
     }
 }


### PR DESCRIPTION
Fixing some bugs in the slot (de)allocation functions, and in the watermark refilling procedure.

This pull request also introduces a function to compute the current size of a cspace in terms of the number of allocated slots. It is utilised in the `sos/src/tests.c:test_cspace` function.