### PR TITLE
cspace: Fix bitfield bug

### DIFF
--- a/libsel4cspace/include/cspace/bitfield.h
+++ b/libsel4cspace/include/cspace/bitfield.h
@@ -47,12 +47,12 @@ static inline unsigned long bf_first_free(size_t words, unsigned long bits[words
 
     unsigned long bit = i * WORD_BITS;
 
-    /* we want to find the first 0 bit, do this by inverting the value */
-    unsigned long val = ~bits[i];
-    /* it's illegal to call CLZL on 0, so check first */
-    assert(val != 0);
-
     if (i < words) {
+        /* we want to find the first 0 bit, do this by inverting the value */
+        unsigned long val = ~bits[i];
+        /* it's illegal to call CLZL on 0, so check first */
+        assert(val != 0);
+
         bit += (CTZL(val));
     }
     return bit;

--- a/libsel4cspace/include/cspace/cspace.h
+++ b/libsel4cspace/include/cspace/cspace.h
@@ -220,6 +220,14 @@ seL4_CPtr cspace_alloc_slot(cspace_t *c);
  */
 void cspace_free_slot(cspace_t *c, seL4_CPtr slot);
 
+/**
+ * Return the current size of the cspace in filled slots.
+ *
+ * @param c    The cspace
+ * @return The number of capabilities currently stored in the cspace.
+ */
+seL4_Word cspace_size(cspace_t *c);
+
 /* helper functions for cspace operations */
 
 /**


### PR DESCRIPTION
In the course of fixing other bugs, 57d4b41 moved the read of the bits
array outside the bounds checking of the index. The bug can manifest as
a failed assertion if the value on the stack preceding the bits array is
ULONG_MAX. In any case, it's probably best not to touch data outside the
bounds of the provided array.