### PR TITLE
Fixes for seL4 version 13.0.0

### DIFF
--- a/sos/src/bootstrap.c
+++ b/sos/src/bootstrap.c
@@ -278,6 +278,7 @@ void sos_bootstrap(cspace_t *cspace, const seL4_BootInfo *bi)
         case seL4_CapIOSpace:
         case seL4_CapSMMUSIDControl:
         case seL4_CapSMMUCBControl:
+        case seL4_CapSMC:
             continue;
         }
         ZF_LOGV("cspace: moving cap %lu boot -> new cspace", i);


### PR DESCRIPTION
These are changes required to AOS to make it work with [seL4 version 13.0.0](https://github.com/seL4/seL4/releases/tag/13.0.0).

The breaking change that needs to be fixed is

> libsel4: Make bootinfo consistent. Some slot positions in the rootnode would depend on configuration. However that makes it difficult to add new root caps, especially if multiple caps only exist based on configuration. **Make all caps always there, but null if not configured.**

Also see:
- https://github.com/seL4/seL4/pull/1305