### PR TITLE
gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 ## AOS
 
-/build
+build/
 
 ## CMAKE
 

--- a/aos-make-project.sh
+++ b/aos-make-project.sh
@@ -65,10 +65,9 @@ main () {
 		-srf \
 		"projects/aos/init-build.sh" \
 		"${DEST_REPO}/init-build.sh"
-	ln \
-		-srf \
+	mv \
 		"projects/aos/.gitignore" \
-		"${DEST_REPO}/.gitignore"
+		"${DEST_REPO}"
 	ln \
 		-srf \
 		"projects/aos/settings.cmake" \


### PR DESCRIPTION
- Fixed the gitignore to be moved to the root dir rather than symlinked. This has been an issue since last year where it seems that git changed its behaviour such that it cannot use symlinks.
- Fixed the gitignore to properly ignore the build folder.