### PR TITLE
Disable debugger default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 ## AOS
 
-/build
+build/
 
 ## CMAKE
 

--- a/aos-make-project.sh
+++ b/aos-make-project.sh
@@ -65,10 +65,9 @@ main () {
 		-srf \
 		"projects/aos/init-build.sh" \
 		"${DEST_REPO}/init-build.sh"
-	ln \
-		-srf \
+	mv \
 		"projects/aos/.gitignore" \
-		"${DEST_REPO}/.gitignore"
+		"${DEST_REPO}"
 	ln \
 		-srf \
 		"projects/aos/settings.cmake" \

--- a/settings.cmake
+++ b/settings.cmake
@@ -68,7 +68,7 @@ set(KernelIRQReporting ON CACHE BOOL "" FORCE)
 set(KernelPrinting ON CACHE BOOL "" FORCE)
 set(KernelDebugBuild ON CACHE BOOL "" FORCE)
 set(HardwareDebugAPI ON CACHE BOOL "" FORCE)
-set(SosGDBSupport ON CACHE BOOL "" FORCE) # Enable debugger
+set(SosGDBSupport OFF CACHE BOOL "" FORCE) # Enable debugger
 
 # enable our networking libs
 set(LibPicotcp ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
- Disable the GDB debugger by default in the CMake settings.